### PR TITLE
Fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,6 @@ cargo test
 wasm-pack test --headless --firefox
 ```
 
-### 開発サーバー
-
-```bash
-# 開発用サーバーを起動（例）
-cd www
-npm install
-npm start
-```
 
 ## 📁 プロジェクト構造
 


### PR DESCRIPTION
## Summary
- remove the development server section from README since the repository has no `www` directory

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68499cc378408321895685ab6bcb843e