### PR TITLE
Fix broken README license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ src/
 
 このプロジェクトは以下のライセンスの下で公開されています：
 
-- Apache License 2.0 ([LICENSE_APACHE](LICENSE_APACHE))
+- Apache License 2.0 ([LICENSE](LICENSE))
 
 ## 🤝 コントリビューション
 
@@ -201,7 +201,7 @@ src/
 ## 📞 サポート
 
 - バグ報告: [GitHub Issues](https://github.com/nusu-github/UNIPA-EX-rs/issues)
-- 機能要望: [GitHub Discussions](https://github.com/nusu-github/UNIPA-EX-rs/discussions)
+- 機能要望: [GitHub Issues](https://github.com/nusu-github/UNIPA-EX-rs/issues)
 
 ---
 


### PR DESCRIPTION
## Summary
- fix license link to LICENSE
- replace invalid GitHub Discussions link with Issues link

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68499cc48ca08321814f9b187743d160