### PR TITLE
Remove duplicate HTML entity replacement

### DIFF
--- a/src/parsers/test_answer_status/parser.rs
+++ b/src/parsers/test_answer_status/parser.rs
@@ -417,7 +417,6 @@ impl TestAnswerStatusParserImpl {
             .replace("&#12488;", "ト")
             .replace("&#12479;", "タ")
             .replace("&#12452;", "イ")
-            .replace("&#12488;", "ト")
             .replace("&#12523;", "ル")
             .replace("&#25480;", "授")
             .replace("&#26989;", "業")


### PR DESCRIPTION
## Summary
- fix duplication of `&#12488;` replacement in `decode_html_entities`
- confirm no other duplicates exist

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68499cc4e14483219ff2f0537d6d1fbc