### PR TITLE
Handle unimplemented timetable parsers gracefully

### DIFF
--- a/src/parsers/timetable/course_timetable/calendar_view.rs
+++ b/src/parsers/timetable/course_timetable/calendar_view.rs
@@ -43,6 +43,9 @@ impl PageParser<CourseTimetableCalendar> for CalendarViewParser {
     const PAGE_TYPE: &'static str = "学科開講一覧 表示形式：カレンダー";
 
     fn parse_document(&self, document: &Html) -> Result<CourseTimetableCalendar, ParseError> {
-        todo!()
+        let _ = document; // suppress unused variable warnings
+        Err(ParseError::NotImplemented {
+            operation: "Course timetable calendar view parsing".to_string(),
+        })
     }
 }

--- a/src/parsers/timetable/course_timetable/list_view.rs
+++ b/src/parsers/timetable/course_timetable/list_view.rs
@@ -85,12 +85,18 @@ impl ListViewParser {
 
     /// 学期情報を抽出する
     fn parse_semester_info(&self, document: &Html) -> Result<(u32, String), ParseError> {
-        todo!()
+        let _ = document; // suppress unused variable warnings
+        Err(ParseError::NotImplemented {
+            operation: "Course timetable semester info parsing".to_string(),
+        })
     }
 
     /// 学生情報ラベルを抽出する
     fn parse_student_info_label(&self, document: &Html) -> Result<String, ParseError> {
-        todo!()
+        let _ = document; // suppress unused variable warnings
+        Err(ParseError::NotImplemented {
+            operation: "Course timetable student info label parsing".to_string(),
+        })
     }
 }
 

--- a/src/parsers/timetable/student_timetable/calendar_view.rs
+++ b/src/parsers/timetable/student_timetable/calendar_view.rs
@@ -16,6 +16,9 @@ impl PageParser<StudentTimetable> for CalendarViewParser {
     const PAGE_TYPE: &'static str = "学生時間割表 表示形式：カレンダー";
 
     fn parse_document(&self, document: &Html) -> Result<StudentTimetable, ParseError> {
-        todo!()
+        let _ = document; // suppress unused variable warnings
+        Err(ParseError::NotImplemented {
+            operation: "StudentTimetable calendar view parsing".to_string(),
+        })
     }
 }

--- a/src/parsers/timetable/student_timetable/list_view.rs
+++ b/src/parsers/timetable/student_timetable/list_view.rs
@@ -24,6 +24,9 @@ impl PageParser<StudentTimetable> for ListViewParser {
     const PAGE_TYPE: &'static str = "学生時間割表 表示形式：一覧";
 
     fn parse_document(&self, document: &Html) -> Result<StudentTimetable, ParseError> {
-        todo!()
+        let _ = document; // suppress unused variable warnings
+        Err(ParseError::NotImplemented {
+            operation: "StudentTimetable list view parsing".to_string(),
+        })
     }
 }

--- a/src/parsers/timetable/teacher_timetable/detail/calendar_view.rs
+++ b/src/parsers/timetable/teacher_timetable/detail/calendar_view.rs
@@ -45,6 +45,9 @@ impl PageParser<TeacherTimetableCalendar> for CalendarViewParser {
     const PAGE_TYPE: &'static str = "教員時間割表 表示形式：カレンダー";
 
     fn parse_document(&self, document: &Html) -> Result<TeacherTimetableCalendar, ParseError> {
-        todo!()
+        let _ = document; // suppress unused variable warnings
+        Err(ParseError::NotImplemented {
+            operation: "Teacher timetable calendar view parsing".to_string(),
+        })
     }
 }

--- a/src/parsers/timetable/teacher_timetable/detail/list_view.rs
+++ b/src/parsers/timetable/teacher_timetable/detail/list_view.rs
@@ -51,6 +51,9 @@ impl PageParser<TeacherTimetableList> for ListViewParser {
     const PAGE_TYPE: &'static str = "教員時間割表 表示形式：一覧";
 
     fn parse_document(&self, document: &Html) -> Result<TeacherTimetableList, ParseError> {
-        todo!()
+        let _ = document; // suppress unused variable warnings
+        Err(ParseError::NotImplemented {
+            operation: "Teacher timetable list view parsing".to_string(),
+        })
     }
 }

--- a/src/parsers/timetable/teacher_timetable/search.rs
+++ b/src/parsers/timetable/teacher_timetable/search.rs
@@ -89,6 +89,9 @@ impl PageParser<TeacherSearchPage> for TeacherSearchParser {
     const PAGE_TYPE: &'static str = "教員時間割検索";
 
     fn parse_document(&self, document: &Html) -> Result<TeacherSearchPage, ParseError> {
-        todo!()
+        let _ = document; // suppress unused variable warnings
+        Err(ParseError::NotImplemented {
+            operation: "Teacher timetable search parsing".to_string(),
+        })
     }
 }


### PR DESCRIPTION
## Summary
- avoid runtime panics in timetable parsers by returning `ParseError::NotImplemented`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684999cd71788321a4abe963b776509f